### PR TITLE
Update Dropdown component to use menu prop instead of overlay

### DIFF
--- a/src/core/common/datePicker.tsx
+++ b/src/core/common/datePicker.tsx
@@ -70,7 +70,7 @@ const PredefinedDatePicker: React.FC = () => {
 
   return (
     <div>
-      <Dropdown overlay={menu} trigger={['click']}>
+      <Dropdown menu={menu} trigger={['click']}>
         <Input
           readOnly
           value={displayValue}


### PR DESCRIPTION
## Changes Made

Updated the `Dropdown` component in `PredefinedDatePicker` to use the `menu` prop instead of the deprecated `overlay` prop.

### Modified Files
- `src/core/common/datePicker.tsx`

### Details
- Changed `<Dropdown overlay={menu} trigger={['click']}>` to `<Dropdown menu={menu} trigger={['click']}>`
- This updates the component to use the current API specification for the Dropdown component

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/67a73739e5c747a4ae41ecb5ed78eea9/pulse-verse)

👀 [Preview Link](https://67a73739e5c747a4ae41ecb5ed78eea9-pulse-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>67a73739e5c747a4ae41ecb5ed78eea9</projectId>-->
<!--<branchName>pulse-verse</branchName>-->